### PR TITLE
Use ArrayDeque for queue in LockingTree constructor

### DIFF
--- a/juspay prep part a
+++ b/juspay prep part a
@@ -1,5 +1,6 @@
 import java.io.*;
 import java.util.*;
+import java.util.ArrayDeque;
 
 class Node {
     String name;
@@ -27,7 +28,7 @@ public class LockingTree {
         }
         
         Node root = nodeMap.get(nodeNames.get(0));
-        Queue<Node> queue = new LinkedList<>();
+        Queue<Node> queue = new ArrayDeque<>();
         queue.offer(root);
         
         int index = 1;


### PR DESCRIPTION
## Summary
- Replace LinkedList with ArrayDeque for BFS queue in LockingTree.
- Import ArrayDeque to match new queue implementation.

## Testing
- `javac LockingTree.java`


------
https://chatgpt.com/codex/tasks/task_e_6897058d4f18832bacace6baf2d13df7