### PR TITLE
Validate node names in locking operations

### DIFF
--- a/LockingTree.java
+++ b/LockingTree.java
@@ -50,6 +50,8 @@ public class LockingTree {
     
     public boolean lock(String name, int uid) {
         Node node = nodeMap.get(name);
+        if (node == null)
+            return false;
         if (node.lockedBy != -1 || node.lockedDescendantCount > 0)
             return false;
         
@@ -66,7 +68,7 @@ public class LockingTree {
     
     public boolean unlock(String name, int uid) {
         Node node = nodeMap.get(name);
-        if (node.lockedBy != uid) return false;
+        if (node == null || node.lockedBy != uid) return false;
 
         node.lockedBy = -1;
         updateAncestorDescendants(node, -1);
@@ -75,7 +77,7 @@ public class LockingTree {
     
     public boolean upgrade(String name, int uid) {
         Node node = nodeMap.get(name);
-        if (node.lockedBy != -1 || node.lockedDescendants.isEmpty())
+        if (node == null || node.lockedBy != -1 || node.lockedDescendants.isEmpty())
             return false;
 
         for (Node ln : node.lockedDescendants) {

--- a/LockingTreeTest.java
+++ b/LockingTreeTest.java
@@ -1,0 +1,27 @@
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import java.util.List;
+
+public class LockingTreeTest {
+    private LockingTree createTree() {
+        return new LockingTree(3, 2, List.of("A", "B", "C"));
+    }
+
+    @Test
+    public void lockInvalidNodeReturnsFalse() {
+        LockingTree tree = createTree();
+        assertFalse(tree.lock("X", 1));
+    }
+
+    @Test
+    public void unlockInvalidNodeReturnsFalse() {
+        LockingTree tree = createTree();
+        assertFalse(tree.unlock("X", 1));
+    }
+
+    @Test
+    public void upgradeInvalidNodeReturnsFalse() {
+        LockingTree tree = createTree();
+        assertFalse(tree.upgrade("X", 1));
+    }
+}


### PR DESCRIPTION
## Summary
- handle missing nodes in `lock`, `unlock`, and `upgrade`
- cover invalid node names with unit tests

## Testing
- `javac -cp junit-platform-console-standalone.jar:. LockingTree.java LockingTreeTest.java`
- `java -jar junit-platform-console-standalone.jar -cp . --select-class LockingTreeTest`


------
https://chatgpt.com/codex/tasks/task_e_689735e6246c832bb655a1a07b312ee0