### PR TITLE
Add P2P payment service prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.venv/
+__pycache__/
+*.pyc
+data/p2p.db

--- a/README.md
+++ b/README.md
@@ -1,0 +1,86 @@
+# P2P Payment Service (Prototype)
+
+A near-production P2P payment service prototype built with **FastAPI + SQLite**. It emphasizes correctness, idempotency, and ledger integrity while remaining lightweight for local development.
+
+## Highlights
+- **Atomic transfers** using transactional SQLite `BEGIN IMMEDIATE` to prevent race conditions.
+- **Idempotency** on transfers to avoid duplicate debits in retries.
+- **Ledger entries** for each payment to support audit trails.
+- **Clean HTTP APIs** with explicit error handling and validation.
+
+## System Design
+
+### Components
+- **FastAPI API layer**: request validation, routing, and error translation.
+- **Service layer**: orchestrates transfers and enforces business rules.
+- **SQLite database**: stores users, accounts, payments, and ledger entries.
+
+### Data Model
+- `users`: account owners, unique by email.
+- `accounts`: balances in integer minor units (e.g., cents).
+- `payments`: transfer records with idempotency keys.
+- `ledger_entries`: debit/credit entries with running balances.
+
+### Transfer Flow
+1. Validate request and idempotency key.
+2. Lock the sender/receiver accounts with a single transactional connection.
+3. Enforce:
+   - Active accounts
+   - Same currency
+   - Sufficient funds
+4. Apply balance updates.
+5. Create payment + ledger entries.
+
+### Robustness Features
+- **Idempotency** via `(sender_account_id, idempotency_key)` uniqueness.
+- **Transactional integrity**: either everything is written or nothing is.
+- **Typed validation**: Pydantic schemas enforce input constraints.
+
+## API Reference
+
+### POST `/users`
+Create a user.
+
+### POST `/accounts`
+Create an account for a user.
+
+### GET `/accounts/{account_id}`
+Fetch account details and balances.
+
+### POST `/payments/transfer`
+Transfer funds between accounts.
+
+Headers:
+- `Idempotency-Key`: required
+
+### GET `/payments/{payment_id}`
+Fetch payment details.
+
+### GET `/accounts/{account_id}/ledger`
+List ledger entries for an account.
+
+## Local Development
+
+### Install
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+### Run the API
+```bash
+uvicorn p2p_service.app:app --reload
+```
+
+### Run tests
+```bash
+pytest
+```
+
+## Production Considerations (Next Steps)
+- Replace SQLite with PostgreSQL and add row-level locking.
+- Add auth, rate limiting, and request signing.
+- Add background jobs for settlement or reconciliation.
+- Integrate observability (structured logging + metrics).
+- Add more exhaustive tests for concurrency and failure modes.

--- a/TEST_RUNS.md
+++ b/TEST_RUNS.md
@@ -1,0 +1,10 @@
+# Test Runs
+
+## Local Test Command
+```bash
+pytest
+```
+
+## Notes
+- Run the test command after installing dependencies from `requirements.txt`.
+- The test suite validates user creation, account setup, transfers, and idempotency behavior.

--- a/p2p_service/__init__.py
+++ b/p2p_service/__init__.py
@@ -1,0 +1,1 @@
+"""P2P payment service package."""

--- a/p2p_service/app.py
+++ b/p2p_service/app.py
@@ -1,0 +1,100 @@
+from fastapi import Depends, FastAPI, Header, HTTPException, status
+
+from . import service
+from .db import init_db
+from .schemas import (
+    AccountCreate,
+    AccountResponse,
+    PaymentResponse,
+    TransferRequest,
+    UserCreate,
+    UserResponse,
+)
+
+app = FastAPI(title="P2P Payment Service", version="0.1.0")
+
+
+def init() -> None:
+    init_db()
+
+
+@app.on_event("startup")
+def startup_event() -> None:
+    init()
+
+
+@app.get("/health")
+def health() -> dict:
+    return {"status": "ok"}
+
+
+@app.post("/users", response_model=UserResponse, status_code=status.HTTP_201_CREATED)
+def create_user(payload: UserCreate) -> dict:
+    try:
+        return service.create_user(payload.name, payload.email)
+    except Exception as exc:
+        if "UNIQUE" in str(exc):
+            raise HTTPException(status_code=409, detail="email_already_exists") from exc
+        raise
+
+
+@app.post("/accounts", response_model=AccountResponse, status_code=status.HTTP_201_CREATED)
+def create_account(payload: AccountCreate) -> dict:
+    try:
+        return service.create_account(payload.user_id, payload.currency, payload.initial_balance)
+    except ValueError as exc:
+        if str(exc) == "user_not_found":
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        raise
+
+
+@app.get("/accounts/{account_id}", response_model=AccountResponse)
+def get_account(account_id: str) -> dict:
+    try:
+        return service.get_account(account_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@app.post("/payments/transfer", response_model=PaymentResponse, status_code=status.HTTP_201_CREATED)
+def transfer(
+    payload: TransferRequest,
+    idempotency_key: str = Header(..., alias="Idempotency-Key"),
+) -> dict:
+    try:
+        return service.transfer_funds(
+            payload.sender_account_id,
+            payload.receiver_account_id,
+            payload.amount,
+            payload.currency,
+            idempotency_key,
+        )
+    except ValueError as exc:
+        mapping = {
+            "same_account_transfer": (400, "same_account_transfer"),
+            "account_not_found": (404, "account_not_found"),
+            "account_inactive": (409, "account_inactive"),
+            "currency_mismatch": (409, "currency_mismatch"),
+            "insufficient_funds": (409, "insufficient_funds"),
+        }
+        if str(exc) in mapping:
+            status_code, detail = mapping[str(exc)]
+            raise HTTPException(status_code=status_code, detail=detail) from exc
+        raise
+
+
+@app.get("/payments/{payment_id}", response_model=PaymentResponse)
+def get_payment(payment_id: str) -> dict:
+    try:
+        return service.get_payment(payment_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@app.get("/accounts/{account_id}/ledger")
+def get_ledger(account_id: str) -> dict:
+    try:
+        entries = service.list_ledger(account_id)
+        return {"entries": entries}
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc

--- a/p2p_service/db.py
+++ b/p2p_service/db.py
@@ -1,0 +1,78 @@
+import contextlib
+import sqlite3
+from pathlib import Path
+from typing import Iterator
+
+DATABASE_PATH = Path(__file__).resolve().parent.parent / "data" / "p2p.db"
+
+
+def get_connection() -> sqlite3.Connection:
+    DATABASE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(DATABASE_PATH)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    return conn
+
+
+@contextlib.contextmanager
+def transaction() -> Iterator[sqlite3.Connection]:
+    conn = get_connection()
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        yield conn
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+def init_db() -> None:
+    with get_connection() as conn:
+        conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS users (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                email TEXT NOT NULL UNIQUE,
+                created_at TEXT NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS accounts (
+                id TEXT PRIMARY KEY,
+                user_id TEXT NOT NULL,
+                currency TEXT NOT NULL,
+                balance INTEGER NOT NULL,
+                status TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                FOREIGN KEY (user_id) REFERENCES users (id)
+            );
+
+            CREATE TABLE IF NOT EXISTS payments (
+                id TEXT PRIMARY KEY,
+                sender_account_id TEXT NOT NULL,
+                receiver_account_id TEXT NOT NULL,
+                amount INTEGER NOT NULL,
+                currency TEXT NOT NULL,
+                status TEXT NOT NULL,
+                idempotency_key TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                UNIQUE (sender_account_id, idempotency_key),
+                FOREIGN KEY (sender_account_id) REFERENCES accounts (id),
+                FOREIGN KEY (receiver_account_id) REFERENCES accounts (id)
+            );
+
+            CREATE TABLE IF NOT EXISTS ledger_entries (
+                id TEXT PRIMARY KEY,
+                account_id TEXT NOT NULL,
+                payment_id TEXT NOT NULL,
+                direction TEXT NOT NULL,
+                amount INTEGER NOT NULL,
+                balance_after INTEGER NOT NULL,
+                created_at TEXT NOT NULL,
+                FOREIGN KEY (account_id) REFERENCES accounts (id),
+                FOREIGN KEY (payment_id) REFERENCES payments (id)
+            );
+            """
+        )

--- a/p2p_service/schemas.py
+++ b/p2p_service/schemas.py
@@ -1,0 +1,45 @@
+from pydantic import BaseModel, Field
+
+
+class UserCreate(BaseModel):
+    name: str = Field(..., min_length=1, max_length=100)
+    email: str = Field(..., min_length=3, max_length=255)
+
+
+class UserResponse(BaseModel):
+    id: str
+    name: str
+    email: str
+    created_at: str
+
+
+class AccountCreate(BaseModel):
+    user_id: str
+    currency: str = Field(..., min_length=3, max_length=3)
+    initial_balance: int = Field(ge=0)
+
+
+class AccountResponse(BaseModel):
+    id: str
+    user_id: str
+    currency: str
+    balance: int
+    status: str
+    created_at: str
+
+
+class TransferRequest(BaseModel):
+    sender_account_id: str
+    receiver_account_id: str
+    amount: int = Field(..., gt=0)
+    currency: str = Field(..., min_length=3, max_length=3)
+
+
+class PaymentResponse(BaseModel):
+    id: str
+    sender_account_id: str
+    receiver_account_id: str
+    amount: int
+    currency: str
+    status: str
+    created_at: str

--- a/p2p_service/service.py
+++ b/p2p_service/service.py
@@ -1,0 +1,174 @@
+import uuid
+from datetime import datetime, timezone
+from typing import Iterable, Mapping
+
+from .db import transaction
+
+ISO_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).strftime(ISO_FORMAT)
+
+
+def _row_to_dict(row: Mapping) -> dict:
+    return dict(row)
+
+
+def create_user(name: str, email: str) -> dict:
+    user_id = str(uuid.uuid4())
+    created_at = _utc_now()
+    with transaction() as conn:
+        conn.execute(
+            "INSERT INTO users (id, name, email, created_at) VALUES (?, ?, ?, ?)",
+            (user_id, name, email, created_at),
+        )
+    return {
+        "id": user_id,
+        "name": name,
+        "email": email,
+        "created_at": created_at,
+    }
+
+
+def create_account(user_id: str, currency: str, initial_balance: int) -> dict:
+    account_id = str(uuid.uuid4())
+    created_at = _utc_now()
+    with transaction() as conn:
+        user = conn.execute("SELECT id FROM users WHERE id = ?", (user_id,)).fetchone()
+        if user is None:
+            raise ValueError("user_not_found")
+        conn.execute(
+            "INSERT INTO accounts (id, user_id, currency, balance, status, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (account_id, user_id, currency.upper(), initial_balance, "active", created_at),
+        )
+    return {
+        "id": account_id,
+        "user_id": user_id,
+        "currency": currency.upper(),
+        "balance": initial_balance,
+        "status": "active",
+        "created_at": created_at,
+    }
+
+
+def get_account(account_id: str) -> dict:
+    with transaction() as conn:
+        row = conn.execute("SELECT * FROM accounts WHERE id = ?", (account_id,)).fetchone()
+        if row is None:
+            raise ValueError("account_not_found")
+        return _row_to_dict(row)
+
+
+def get_payment(payment_id: str) -> dict:
+    with transaction() as conn:
+        row = conn.execute("SELECT * FROM payments WHERE id = ?", (payment_id,)).fetchone()
+        if row is None:
+            raise ValueError("payment_not_found")
+        return _row_to_dict(row)
+
+
+def transfer_funds(
+    sender_account_id: str,
+    receiver_account_id: str,
+    amount: int,
+    currency: str,
+    idempotency_key: str,
+) -> dict:
+    if sender_account_id == receiver_account_id:
+        raise ValueError("same_account_transfer")
+
+    currency = currency.upper()
+    with transaction() as conn:
+        existing = conn.execute(
+            "SELECT * FROM payments WHERE sender_account_id = ? AND idempotency_key = ?",
+            (sender_account_id, idempotency_key),
+        ).fetchone()
+        if existing is not None:
+            return _row_to_dict(existing)
+
+        sender = conn.execute("SELECT * FROM accounts WHERE id = ?", (sender_account_id,)).fetchone()
+        receiver = conn.execute("SELECT * FROM accounts WHERE id = ?", (receiver_account_id,)).fetchone()
+        if sender is None or receiver is None:
+            raise ValueError("account_not_found")
+        if sender["status"] != "active" or receiver["status"] != "active":
+            raise ValueError("account_inactive")
+        if sender["currency"] != currency or receiver["currency"] != currency:
+            raise ValueError("currency_mismatch")
+        if sender["balance"] < amount:
+            raise ValueError("insufficient_funds")
+
+        payment_id = str(uuid.uuid4())
+        created_at = _utc_now()
+
+        new_sender_balance = sender["balance"] - amount
+        new_receiver_balance = receiver["balance"] + amount
+
+        conn.execute(
+            "UPDATE accounts SET balance = ? WHERE id = ?",
+            (new_sender_balance, sender_account_id),
+        )
+        conn.execute(
+            "UPDATE accounts SET balance = ? WHERE id = ?",
+            (new_receiver_balance, receiver_account_id),
+        )
+        conn.execute(
+            "INSERT INTO payments (id, sender_account_id, receiver_account_id, amount, currency, status, idempotency_key, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                payment_id,
+                sender_account_id,
+                receiver_account_id,
+                amount,
+                currency,
+                "completed",
+                idempotency_key,
+                created_at,
+            ),
+        )
+
+        ledger_entries = [
+            (
+                str(uuid.uuid4()),
+                sender_account_id,
+                payment_id,
+                "debit",
+                amount,
+                new_sender_balance,
+                created_at,
+            ),
+            (
+                str(uuid.uuid4()),
+                receiver_account_id,
+                payment_id,
+                "credit",
+                amount,
+                new_receiver_balance,
+                created_at,
+            ),
+        ]
+        conn.executemany(
+            "INSERT INTO ledger_entries (id, account_id, payment_id, direction, amount, balance_after, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ledger_entries,
+        )
+
+        return {
+            "id": payment_id,
+            "sender_account_id": sender_account_id,
+            "receiver_account_id": receiver_account_id,
+            "amount": amount,
+            "currency": currency,
+            "status": "completed",
+            "created_at": created_at,
+        }
+
+
+def list_ledger(account_id: str) -> Iterable[dict]:
+    with transaction() as conn:
+        rows = conn.execute(
+            "SELECT * FROM ledger_entries WHERE account_id = ? ORDER BY created_at DESC",
+            (account_id,),
+        ).fetchall()
+        return [_row_to_dict(row) for row in rows]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi==0.115.0
+uvicorn==0.30.6
+pydantic==2.9.2
+pytest==8.3.3
+httpx==0.27.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_payments.py
+++ b/tests/test_payments.py
@@ -1,0 +1,61 @@
+from fastapi.testclient import TestClient
+
+from p2p_service.app import app
+from p2p_service.db import init_db
+
+
+client = TestClient(app)
+
+
+def setup_module() -> None:
+    init_db()
+
+
+def test_full_transfer_flow() -> None:
+    user_a = client.post("/users", json={"name": "Alice", "email": "alice@example.com"})
+    user_b = client.post("/users", json={"name": "Bob", "email": "bob@example.com"})
+    assert user_a.status_code == 201
+    assert user_b.status_code == 201
+
+    account_a = client.post(
+        "/accounts",
+        json={"user_id": user_a.json()["id"], "currency": "USD", "initial_balance": 10000},
+    )
+    account_b = client.post(
+        "/accounts",
+        json={"user_id": user_b.json()["id"], "currency": "USD", "initial_balance": 2500},
+    )
+    assert account_a.status_code == 201
+    assert account_b.status_code == 201
+
+    transfer = client.post(
+        "/payments/transfer",
+        headers={"Idempotency-Key": "transfer-1"},
+        json={
+            "sender_account_id": account_a.json()["id"],
+            "receiver_account_id": account_b.json()["id"],
+            "amount": 1500,
+            "currency": "USD",
+        },
+    )
+    assert transfer.status_code == 201
+    payment = transfer.json()
+    assert payment["status"] == "completed"
+
+    duplicate = client.post(
+        "/payments/transfer",
+        headers={"Idempotency-Key": "transfer-1"},
+        json={
+            "sender_account_id": account_a.json()["id"],
+            "receiver_account_id": account_b.json()["id"],
+            "amount": 1500,
+            "currency": "USD",
+        },
+    )
+    assert duplicate.status_code == 201
+    assert duplicate.json()["id"] == payment["id"]
+
+    account_a_refresh = client.get(f"/accounts/{account_a.json()['id']}")
+    account_b_refresh = client.get(f"/accounts/{account_b.json()['id']}")
+    assert account_a_refresh.json()["balance"] == 8500
+    assert account_b_refresh.json()["balance"] == 4000


### PR DESCRIPTION
### Motivation
- Provide a near-production prototype of a P2P payment service that demonstrates atomic transfers, idempotency, and ledgered bookkeeping.
- Surface a minimal, testable HTTP API implementation so the design can be iterated and hardened for production (DB swap, auth, observability).

### Description
- Add a FastAPI application (`p2p_service/app.py`) exposing endpoints for user/account creation, transfers (`/payments/transfer`), payment lookup, and account ledger retrieval. 
- Implement a transactional SQLite persistence layer with `get_connection`, `transaction`, and `init_db` in `p2p_service/db.py`, including schema for `users`, `accounts`, `payments`, and `ledger_entries`.
- Implement core business logic in `p2p_service/service.py` enforcing active accounts, currency matching, sufficient funds, idempotent transfers (unique `(sender_account_id, idempotency_key)`), balance updates, payment records, and ledger entries.
- Add Pydantic schemas in `p2p_service/schemas.py`, a test suite (`tests/test_payments.py` and `tests/conftest.py`), `README.md`, `TEST_RUNS.md`, `requirements.txt`, and `.gitignore`.

### Testing
- Ran `pytest`, which executed `tests/test_payments.py` and completed successfully with `1 passed` (there were 2 deprecation warnings related to `@app.on_event` usage). 
- The test covers end-to-end user and account creation, transfer execution, idempotency of duplicate transfer requests, and final balance assertions.
- Use `pytest` locally after installing dependencies with `pip install -r requirements.txt` to reproduce the run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ebc891238832b83bc0936490734bb)